### PR TITLE
Preserve Doorstop injection for Valheim macOS Rosetta launches

### DIFF
--- a/scripts/Start scripts/start_game_bepinex.sh
+++ b/scripts/Start scripts/start_game_bepinex.sh
@@ -271,12 +271,37 @@ export DOORSTOP_MONO_DEBUG_SUSPEND="$debug_suspend"
 # Final setup
 doorstop_directory="${BASEDIR}/doorstop_libs"
 doorstop_name="libdoorstop_${arch}.${lib_extension}"
+doorstop_path="${doorstop_directory}/${doorstop_name}"
 
 export LD_LIBRARY_PATH="${doorstop_directory}:${LD_LIBRARY_PATH}"
 if [ -z "$LD_PRELOAD" ]; then
     export LD_PRELOAD="${doorstop_name}"
 else
     export LD_PRELOAD="${doorstop_name}:${LD_PRELOAD}"
+fi
+
+if [ "${os_type}" = "Darwin" ] && [ "${arch}" = "x64" ] && command -v arch >/dev/null 2>&1; then
+    exec arch -x86_64 /bin/sh -c '
+        doorstop_directory="$1"
+        doorstop_path="$2"
+        existing_dyld_library_path="$3"
+        existing_dyld_insert_libraries="$4"
+        shift 4
+
+        if [ -z "$existing_dyld_library_path" ]; then
+            export DYLD_LIBRARY_PATH="$doorstop_directory"
+        else
+            export DYLD_LIBRARY_PATH="$doorstop_directory:$existing_dyld_library_path"
+        fi
+
+        if [ -z "$existing_dyld_insert_libraries" ]; then
+            export DYLD_INSERT_LIBRARIES="$doorstop_path"
+        else
+            export DYLD_INSERT_LIBRARIES="$doorstop_path:$existing_dyld_insert_libraries"
+        fi
+
+        exec "$@"
+    ' sh "$doorstop_directory" "$doorstop_path" "$DYLD_LIBRARY_PATH" "$DYLD_INSERT_LIBRARIES" "$executable_path" "$@"
 fi
 
 export DYLD_LIBRARY_PATH="${doorstop_directory}:${DYLD_LIBRARY_PATH}"


### PR DESCRIPTION
## Summary

Fixes #21.

This is a small macOS workaround for current Valheim/BepInExPack users on Apple Silicon.

When the Valheim start script runs the x86_64 game slice through Rosetta, Doorstop can fail to inject because the `DYLD_*` variables used for `libdoorstop_x64.dylib` are not present in the final Valheim process. The result is confusing for users: Valheim launches normally, but BepInEx never creates `BepInEx/LogOutput.log` and no plugins load.

This patch keeps the change limited to `scripts/Start scripts/start_game_bepinex.sh`:

- adds a full `doorstop_path`
- for macOS x64 launches, enters an x86_64 shell first
- sets `DYLD_LIBRARY_PATH` and `DYLD_INSERT_LIBRARIES` inside that shell
- then `exec`s the Valheim executable

This is intentionally narrower than #20. It does not attempt native arm64 support or broader runtime changes; it is just a compatibility workaround for the current packaged Valheim launch path.

## Local validation

Validated on:

- macOS `26.3.1` (`25D2128`)
- Apple M4
- Valheim `0.221.12` (network version `36`)
- `BepInExPack_Valheim 5.4.2333`

Before the workaround:

- Valheim launched.
- `BepInEx/LogOutput.log` was not created.
- No plugins loaded.

After the workaround:

```text
[Message:   BepInEx] Chainloader started
[Info   :   BepInEx] 11 plugins to load
[Message:   BepInEx] Chainloader startup complete
```

## Notes

I opened this as a small PR because the broader Apple Silicon work in #20 is still draft. If you would rather fold this into that PR, I am fine with closing this.

This patch was prepared with AI assistance from Codex and validated locally on the machine above.
